### PR TITLE
set minimum of 1 for hcr

### DIFF
--- a/512-hcr/manifests/main.yaml
+++ b/512-hcr/manifests/main.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: dkhptd
 spec:
   template:
+    metadata:
+      annotations:
+        autoscaling.knative.dev/min-scale: "1"
     spec:
       containers:
         - image: tuana9a/hcr
@@ -17,5 +20,5 @@ spec:
               memory: "300Mi"
               cpu: "300m"
             limits:
-              memory: "1000Mi"
-              cpu: "1000m"
+              memory: "1500Mi"
+              cpu: "1500m"


### PR DESCRIPTION
hcr image is big ~ 3GB so scale it to 0 make it super long to start back. So set minimum of 1 will help it alot.