### PR TITLE
refactor(argocd): disable prune as it's so painful

### DIFF
--- a/100-argo-apps/100-argo-apps.yaml
+++ b/100-argo-apps/100-argo-apps.yaml
@@ -15,6 +15,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/150-metrics-server.yaml
+++ b/100-argo-apps/150-metrics-server.yaml
@@ -24,6 +24,6 @@ spec:
     namespace: metrics-server
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/190-metallb-manifests.yaml
+++ b/100-argo-apps/190-metallb-manifests.yaml
@@ -15,6 +15,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/190-metallb.yaml
+++ b/100-argo-apps/190-metallb.yaml
@@ -21,6 +21,6 @@ spec:
     namespace: metallb-system
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/200-cert-manager-issuers.yaml
+++ b/100-argo-apps/200-cert-manager-issuers.yaml
@@ -15,6 +15,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/200-cert-manager.yaml
+++ b/100-argo-apps/200-cert-manager.yaml
@@ -26,6 +26,6 @@ spec:
     namespace: cert-manager
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/200-external-dns.yaml
+++ b/100-argo-apps/200-external-dns.yaml
@@ -30,6 +30,6 @@ spec:
     namespace: external-dns
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/200-ingress-nginx.yaml
+++ b/100-argo-apps/200-ingress-nginx.yaml
@@ -34,6 +34,6 @@ spec:
     namespace: ingress-nginx
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/210-knative.yaml
+++ b/100-argo-apps/210-knative.yaml
@@ -14,6 +14,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: false

--- a/100-argo-apps/502-coder.yaml
+++ b/100-argo-apps/502-coder.yaml
@@ -15,6 +15,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/510-t9stbot.yaml
+++ b/100-argo-apps/510-t9stbot.yaml
@@ -20,6 +20,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/511-dkhptd.yaml
+++ b/100-argo-apps/511-dkhptd.yaml
@@ -20,6 +20,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/512-hcr.yaml
+++ b/100-argo-apps/512-hcr.yaml
@@ -20,6 +20,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true

--- a/100-argo-apps/600-k8s-forwarder.yaml
+++ b/100-argo-apps/600-k8s-forwarder.yaml
@@ -20,6 +20,6 @@ spec:
     targetRevision: main
   syncPolicy:
     automated:
-      allowEmpty: true
-      prune: true
+      allowEmpty: false
+      prune: false
       selfHeal: true


### PR DESCRIPTION
While developing, it's so easy to switch to the dev branch for testing, and after that, we forget and switch back to the main branch, if enabling the auto prune, some resources are deleted unexpectedly. I faced a situation where the whole namespace was deleted causing trouble.