### PR TITLE
fix(k8s-fowarder): correct namespace

### DIFF
--- a/600-k8s-forwarder-manifests/tuana9a-dev-code-server-forwarder.yaml
+++ b/600-k8s-forwarder-manifests/tuana9a-dev-code-server-forwarder.yaml
@@ -52,7 +52,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: wildcard-tuana9a-dev-code-server-forwarder
-  namespace: tuana9a
   annotations:
     cert-manager.io/cluster-issuer: "letsencrypt-cloudflare-production"
     nginx.ingress.kubernetes.io/ssl-redirect: "false"


### PR DESCRIPTION
The namespace is handled automatically by argocd app's destination, remove it to make it work.