### PR TITLE
fix: add annotations cname for cert-manager acme http resolver

### DIFF
--- a/200-cert-manager/manifests/cluster-issuer-letsencrypt-production.yml
+++ b/200-cert-manager/manifests/cluster-issuer-letsencrypt-production.yml
@@ -12,3 +12,7 @@ spec:
       - http01:
           ingress:
             ingressClassName: nginx
+            ingressTemplate:
+              metadata:
+                annotations:
+                  external-dns.alpha.kubernetes.io/target: "xenomorph.tuana9a.com"


### PR DESCRIPTION
# what a conflict
- we using `cert-manager` to renew cert
- we using `external-dns` to update dns

the flow to renew cert is:
1. cert-manager create an ingress with that hostname
2. external-dns pick up ingress and update dns record (using load balancer ip by default)
3. the cert should be issued and we're good

but with my setup I need to specify the external-dns to use cname instead (as the load balancer I'm using is metallb which its ip is private ip and I setup a public server with the same as that cname to forward to that load balancer ip)

the annotation for that cname is `external-dns.alpha.kubernetes.io/target`

so here is where conflict begin: for example:
- I'm using grafana and already specify the cname annotation to point to that public server hostname
- external-dns first will update the dns point to use that cname -> we're good now, every one is happy
- but when cert-manager needs to renew those certificate It create a new ingress (I'm using http ingress resolver mode) with the same hostname grafana having no annotation for that cname
- by default the external-dns will use the load balancer ip of the ingress to update the dns
- so external-dns is confused: with the same hostname for grafana but having 2 ingress
  - one update using cname
  - one update using private ip

# the fix

add annotations to the certmanager acme http resolver ingress, luckily the cert-manager support that for us, this PR is for it.